### PR TITLE
Introduser logback-appender for logging på JSON-format

### DIFF
--- a/integrasjonspunkt/src/main/resources/logback-spring.xml
+++ b/integrasjonspunkt/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <!-- Logstash destination -->
     <springProperty name="destination" source="app.logger.destination"/>
     <springProperty name="destination2" source="app.logger.destination2"/>
-    <springProperty name="appender" source="app.logger.appender"/>
+    <springProperty name="stdoutAppender" source="app.logger.stdoutAppender"/>
     <springProperty name="profiles" source="spring.profiles.active"/>
     <springProperty name="orgnr" source="difi.move.org.number"/>
     <springProperty name="enableLogstash" source="app.logger.enableLogstash"/>
@@ -104,7 +104,7 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="${appender:-CONSOLE}"/>
+        <appender-ref ref="${stdoutAppender:-CONSOLE}"/>
         <appender-ref ref="FILE"/>
     </root>
 

--- a/integrasjonspunkt/src/main/resources/logback-spring.xml
+++ b/integrasjonspunkt/src/main/resources/logback-spring.xml
@@ -58,6 +58,27 @@
                 </then>
             </if>
 
+            <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                        <timestamp/>
+                        <logstashMarkers/>
+                        <pattern>
+                            <pattern>
+                                {
+                                "level": "%level",
+                                "message": "%replace(%msg){'[0-9]{11}','**********'}",
+                                "stack_trace": "%replace(%ex{full}){'[0-9]{11}','**********'}",
+                                "class": "%class",
+                                "method": "%method",
+                                "appname": "@project.artifactId@"
+                                }
+                            </pattern>
+                        </pattern>
+                    </providers>
+                </encoder>
+            </appender>
+
             <root level="INFO">
                 <appender-ref ref="stash"/>
                 <if condition='isDefined("destination2")'>

--- a/integrasjonspunkt/src/main/resources/logback-spring.xml
+++ b/integrasjonspunkt/src/main/resources/logback-spring.xml
@@ -8,6 +8,7 @@
     <!-- Logstash destination -->
     <springProperty name="destination" source="app.logger.destination"/>
     <springProperty name="destination2" source="app.logger.destination2"/>
+    <springProperty name="appender" source="app.logger.appender"/>
     <springProperty name="profiles" source="spring.profiles.active"/>
     <springProperty name="orgnr" source="difi.move.org.number"/>
     <springProperty name="enableLogstash" source="app.logger.enableLogstash"/>
@@ -103,7 +104,7 @@
     </if>
 
     <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="${appender:-CONSOLE}"/>
         <appender-ref ref="FILE"/>
     </root>
 

--- a/integrasjonspunkt/src/main/resources/logback-spring.xml
+++ b/integrasjonspunkt/src/main/resources/logback-spring.xml
@@ -62,27 +62,6 @@
                 </then>
             </if>
 
-            <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-                    <providers>
-                        <timestamp/>
-                        <logstashMarkers/>
-                        <pattern>
-                            <pattern>
-                                {
-                                "level": "%level",
-                                "message": "%replace(%msg){'[0-9]{11}','**********'}",
-                                "stack_trace": "%replace(%ex{full}){'[0-9]{11}','**********'}",
-                                "class": "%class",
-                                "method": "%method",
-                                "appname": "@project.artifactId@"
-                                }
-                            </pattern>
-                        </pattern>
-                    </providers>
-                </encoder>
-            </appender>
-
             <root level="INFO">
                 <appender-ref ref="stash"/>
                 <if condition='isDefined("destination2")'>
@@ -102,6 +81,27 @@
             </logger>
         </then>
     </if>
+
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp/>
+                <logstashMarkers/>
+                <pattern>
+                    <pattern>
+                        {
+                        "level": "%level",
+                        "message": "%replace(%msg){'[0-9]{11}','**********'}",
+                        "stack_trace": "%replace(%ex{full}){'[0-9]{11}','**********'}",
+                        "class": "%class",
+                        "method": "%method",
+                        "appname": "@project.artifactId@"
+                        }
+                    </pattern>
+                </pattern>
+            </providers>
+        </encoder>
+    </appender>
 
     <root level="INFO">
         <appender-ref ref="${appender:-CONSOLE}"/>

--- a/integrasjonspunkt/src/main/resources/logback-spring.xml
+++ b/integrasjonspunkt/src/main/resources/logback-spring.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
     <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
     <!-- Logstash destination -->
     <springProperty name="destination" source="app.logger.destination"/>


### PR DESCRIPTION
Heisann! Var ikke sikker på om dere foretrakk engelsk beskrivelse, så holdt meg til norsk.

**Bakgrunn for endring**
Jeg er en utvikler som sitter på Utviklings- og kompetanseetaten på Helsfyr. Vi drifter i dag en instans av integrasjonspunktet i vårt miljø, og har ønsket mulighet for logging med JSON-formattering, da vi har hatt vansker med å agere på forskjellige severity-nivåer (`level`) med vårt gjeldende overvåkningsverktøy. 

Etter prat med Erik Aarsand, vår tjenesteforvalter for eInnsyn, ble vi enige om å legge inn et forslag til endring selv.

**Beskrivelse**
Hensikten med endringen er å muliggjøre logging i JSON-format, på en måte som ikke vil påvirke gjeldende konfigurasjoner hos andre som benytter seg av løsningen.

Endringer oppsummert
- Introduser `app.logger.appender`-property, som brukes til å overstyre `CONSOLE`-appender med noe annet. Faller tilbake til `CONSOLE` dersom property ikke er satt, og skal derfor ivareta gjeldende oppførsel for andre konfigurasjoner
- Legg til `JSON`-appender som logger til stdout i JSON-format (`logstash-logback-encoder`-avhengighet var inkludert i prosjekt fra før). Appenderen filtrerer bort personnummer fra `message` og `stack_trace` slik som i TCP-appenderne.
- Trekk ut konfigurasjon fra inkludert `base.xml`-fil for å forhindre at `CONSOLE`-appender ble brukt dersom man ville overstyre det med `app.logger.appender

Jeg var ikke sikker hvilke felt som var lurt å ha med i JSON-appenderen, så jeg tok det jeg anså som å være et greit utgangspunkt, så får dere eventuelt si hva mer som bør tas med.

Ta høyde for at jeg er ikke kjent med deres utviklingsflyt, konvensjoner eller kodekrav, så gi gjerne tilbakemelding dersom noe mangler!

Mvh Joakim