### PR TITLE
MOVE-2430 Krav om gyldig UUID for senderRef er utilsikta innført for best/edu

### DIFF
--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/Scope.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/sbdh/Scope.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import no.difi.meldingsutveksling.validation.OneOf;
+import no.difi.meldingsutveksling.validation.SbdScopeConditionalInstanceIdentifierUuid;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -52,6 +53,7 @@ import java.util.Set;
 @Getter
 @Setter
 @ToString
+@SbdScopeConditionalInstanceIdentifierUuid
 public class Scope {
 
     @XmlElement(name = "Type", required = true)

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveValidator.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveValidator.java
@@ -11,14 +11,12 @@ import no.difi.meldingsutveksling.api.ConversationService;
 import no.difi.meldingsutveksling.api.OptionalCryptoMessagePersister;
 import no.difi.meldingsutveksling.arkivmelding.ArkivmeldingUtil;
 import no.difi.meldingsutveksling.domain.sbdh.SBDUtil;
-import no.difi.meldingsutveksling.domain.sbdh.ScopeType;
 import no.difi.meldingsutveksling.domain.sbdh.StandardBusinessDocument;
 import no.difi.meldingsutveksling.exceptions.*;
 import no.difi.meldingsutveksling.nextmove.*;
 import no.difi.meldingsutveksling.serviceregistry.externalmodel.ServiceRecord;
 import no.difi.meldingsutveksling.validation.Asserter;
 import no.difi.meldingsutveksling.validation.IntegrasjonspunktCertificateValidator;
-import no.difi.meldingsutveksling.validation.UUIDValidator;
 import no.difi.meldingsutveksling.validation.VirksertCertificateException;
 import no.difi.meldingsutveksling.validation.group.ValidationGroupFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -62,19 +60,6 @@ public class NextMoveValidator {
 
     void validate(StandardBusinessDocument sbd) {
         validateCertificate();
-
-        // Need to validate scopes manually due to ReceiverRef can be non-UUID
-        UUIDValidator uuidValidator = new UUIDValidator();
-        sbd.getOptionalConversationId().ifPresent(cid -> {
-            if (!uuidValidator.isValid(cid, null)) {
-                throw new NotUUIDException(ScopeType.CONVERSATION_ID.getFullname(), cid);
-            }
-        });
-        sbd.findScope(ScopeType.SENDER_REF).ifPresent(sref -> {
-            if (!uuidValidator.isValid(sref.getInstanceIdentifier(), null)) {
-                throw new NotUUIDException(ScopeType.SENDER_REF.getFullname(), sref.getInstanceIdentifier());
-            }
-        });
 
         sbd.getOptionalMessageId().ifPresent(messageId -> {
                     messageRepo.findByMessageId(messageId)

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/validation/SbdScopeConditionalInstanceIdentifierUuidValidator.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/validation/SbdScopeConditionalInstanceIdentifierUuidValidator.java
@@ -1,0 +1,28 @@
+package no.difi.meldingsutveksling.validation;
+
+import no.difi.meldingsutveksling.domain.sbdh.Scope;
+import no.difi.meldingsutveksling.domain.sbdh.ScopeType;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class SbdScopeConditionalInstanceIdentifierUuidValidator implements
+        ConstraintValidator<SbdScopeConditionalInstanceIdentifierUuid, Scope> {
+
+    private final UUIDValidator uuidValidator = new UUIDValidator();
+
+    @Override
+    public boolean isValid(Scope s, ConstraintValidatorContext constraintValidatorContext) {
+        if (ScopeType.CONVERSATION_ID.getFullname().equals(s.getType()) ||
+                ScopeType.SENDER_REF.getFullname().equals(s.getType())) {
+            return uuidValidator.isValid(s.getInstanceIdentifier(), constraintValidatorContext);
+        }
+        // No UUID validation for other scope types
+        return true;
+    }
+
+    @Override
+    public void initialize(SbdScopeConditionalInstanceIdentifierUuid constraintAnnotation) {
+    }
+
+}

--- a/integrasjonspunkt/src/main/resources/META-INF/services/javax.validation.ConstraintValidator
+++ b/integrasjonspunkt/src/main/resources/META-INF/services/javax.validation.ConstraintValidator
@@ -5,3 +5,4 @@ no.difi.meldingsutveksling.validation.InstanceOfValidator
 no.difi.meldingsutveksling.validation.OneOfValidator
 no.difi.meldingsutveksling.validation.UUIDValidator
 no.difi.meldingsutveksling.validation.WebhookFilterValidator
+no.difi.meldingsutveksling.validation.SbdScopeConditionalInstanceIdentifierUuidValidator

--- a/validation/src/main/java/no/difi/meldingsutveksling/validation/SbdScopeConditionalInstanceIdentifierUuid.java
+++ b/validation/src/main/java/no/difi/meldingsutveksling/validation/SbdScopeConditionalInstanceIdentifierUuid.java
@@ -1,0 +1,24 @@
+package no.difi.meldingsutveksling.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+public @interface SbdScopeConditionalInstanceIdentifierUuid {
+
+    String message() default "{no.difi.meldingsutveksling.validation.UUID}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}


### PR DESCRIPTION
MOVE-2430 Krav om gyldig UUID for senderRef er utilsikta innført for best/edu-grensesnittet i integrasjonspunktet 2.2.1

Tidlig oppretta pullrequest, skal legge til automatiserte tester:

- Sending ved bruk av eFormidling 2 skal validere UUID for senderRef men ikkje for receieverRef
- Sending ved bruk av best/edu skal verken validere UUID for senderRef eller receiverRef

Fiksen er kanskje ikkje openbar sett frå koden, men har i praksis rulla tilbake til validering slik det var før - ved deserialisering av SBD - som berre skjer ved bruk av eFormidling 2 grensesnittet - og tilpassa denne. Når valideringa vart flytta til NextMoveValidator tredde valideringa i kraft også for best/edu grensesnittet.