### PR TITLE
Update Dockerfile

### DIFF
--- a/integrasjonspunkt/Dockerfile
+++ b/integrasjonspunkt/Dockerfile
@@ -11,6 +11,7 @@ ENV APP_DIR=/opt/integrasjonspunkt \
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     openssl  && \
     update-ca-certificates && \
     rm -rf /var/cache/apt/* && \


### PR DESCRIPTION
Det er behov for `curl` på grunn av helsesjekken. Uten `curl` vil status bli "unhealthy" (command not found) dersom imaget kjøres som `docker run ...` (og sikkert også om man skulle benytte imaget i et `docker-compose ...`  oppsett.)
 
NB: Hos oss benytter vi egentlig _https_, ikke _http_, men vi kommer rundt dette ved at vi lokalt rekonfigurerer `--health-cmd="curl -s --fail https://localhost:9093/manage/health > /dev/null || exit 1"` og å omgjøre til https vil medføre at dette feiler for andre som ikke har satt opp https.