### PR TITLE
feature-MOVE-2756 rewriting exception handling to use runtime exceptions

### DIFF
--- a/common/src/main/java/no/difi/meldingsutveksling/ResourceUtils.java
+++ b/common/src/main/java/no/difi/meldingsutveksling/ResourceUtils.java
@@ -14,13 +14,8 @@ public class ResourceUtils {
         try (InputStream inputStream = resource.getInputStream()) {
             return IOUtils.toByteArray(inputStream);
         } catch (IOException e) {
-            throw new ResourceUtils.Exception("Couldn't create byte[] out of resource!", e);
+            throw new IllegalStateException("Couldn't create byte[] out of resource!", e);
         }
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/domain/BusinessCertificate.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/domain/BusinessCertificate.java
@@ -1,5 +1,6 @@
 package no.difi.meldingsutveksling.dpi.client.domain;
 
+import lombok.SneakyThrows;
 import lombok.Value;
 
 import java.io.ByteArrayInputStream;
@@ -20,36 +21,31 @@ public class BusinessCertificate {
         return x509Certificate.getPublicKey();
     }
 
+    @SneakyThrows({CertificateEncodingException.class})
     public byte[] getEncoded() {
-        try {
-            return x509Certificate.getEncoded();
-        } catch (CertificateEncodingException e) {
-            throw new Exception("Kunne ikke hente encoded utgave av sertifikatet", e);
-        }
+        return x509Certificate.getEncoded();
     }
 
+    @SneakyThrows({CertificateException.class})
     public static BusinessCertificate of(byte[] certificate) {
-        try {
-            return createBusinessCertificate(certificate);
-        } catch (CertificateException e) {
-            throw new Exception("Kunne ikke lese sertifikat fra byte array", e);
-        }
+        return createBusinessCertificate(certificate);
     }
+
 
     public static BusinessCertificate getFromKeyStore(KeyStore keyStore, String alias) {
         java.security.cert.Certificate certificate;
         try {
             certificate = keyStore.getCertificate(alias);
         } catch (KeyStoreException e) {
-            throw new Exception("Klarte ikke lese sertifikat fra keystore", e);
+            throw new IllegalArgumentException("Klarte ikke lese sertifikat fra keystore", e);
         }
 
         if (certificate == null) {
-            throw new Exception("Kunne ikke finne sertifikat i keystore. Er du sikker på at det er brukt keystore med et sertifikat og at du har oppgitt riktig alias?");
+            throw new IllegalArgumentException("Kunne ikke finne sertifikat i keystore. Er du sikker på at det er brukt keystore med et sertifikat og at du har oppgitt riktig alias?");
         }
 
         if (!(certificate instanceof X509Certificate)) {
-            throw new Exception("Klienten støtter kun X509-sertifikater. Fikk sertifikat av typen " + certificate.getClass().getSimpleName());
+            throw new IllegalArgumentException("Klienten støtter kun X509-sertifikater. Fikk sertifikat av typen " + certificate.getClass().getSimpleName());
         }
 
         return new BusinessCertificate((X509Certificate) certificate);
@@ -60,15 +56,5 @@ public class BusinessCertificate {
                 .getInstance("X509")
                 .generateCertificate(new ByteArrayInputStream(certificate));
         return new BusinessCertificate(x509Certificate);
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message) {
-            super(message);
-        }
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
@@ -26,7 +26,7 @@ public class BusinessCertificateValidator {
      *
      * @param mode One of the modes part of this package.
      * @return Validator for validation of business certificates.
-     * @throws IOException or
+     * @throws IOException               or
      * @throws ValidatorParsingException when loading of validator is unsuccessful.
      */
     @SneakyThrows({IOException.class, ValidatorParsingException.class})
@@ -42,7 +42,7 @@ public class BusinessCertificateValidator {
      *
      * @param mode Some enum annotated with {@link RecipePath}
      * @return Validator for validation of business certificates.
-     * @throws IOException or
+     * @throws IOException               or
      * @throws ValidatorParsingException when loading of validator is unsuccessful.
      */
     @SneakyThrows({IOException.class, ValidatorParsingException.class})
@@ -56,8 +56,8 @@ public class BusinessCertificateValidator {
      *
      * @param modeString Mode as string.
      * @return Validator for validation of business certificates.
-     * @throws IOException or
-     * @throws ValidatorParsingException or
+     * @throws IOException                    or
+     * @throws ValidatorParsingException      or
      * @throws CertificateValidationException when loading of validator is unsuccessful.
      */
     @SneakyThrows({IOException.class, ValidatorParsingException.class, CertificateValidationException.class})

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
@@ -1,5 +1,6 @@
 package no.difi.meldingsutveksling.dpi.client.internal;
 
+import lombok.SneakyThrows;
 import no.difi.certvalidator.Validator;
 import no.difi.certvalidator.ValidatorLoader;
 import no.difi.certvalidator.api.CertificateValidationException;
@@ -25,9 +26,11 @@ public class BusinessCertificateValidator {
      *
      * @param mode One of the modes part of this package.
      * @return Validator for validation of business certificates.
-     * @throws LoadingException when loading of validator is unsuccessful.
+     * @throws IOException or
+     * @throws ValidatorParsingException when loading of validator is unsuccessful.
      */
-    public static BusinessCertificateValidator of(Mode mode) throws LoadingException {
+    @SneakyThrows({IOException.class, ValidatorParsingException.class})
+    public static BusinessCertificateValidator of(Mode mode) {
         return of((Enum<Mode>) mode);
     }
 
@@ -39,9 +42,11 @@ public class BusinessCertificateValidator {
      *
      * @param mode Some enum annotated with {@link RecipePath}
      * @return Validator for validation of business certificates.
-     * @throws LoadingException when loading of validator is unsuccessful.
+     * @throws IOException or
+     * @throws ValidatorParsingException when loading of validator is unsuccessful.
      */
-    public static BusinessCertificateValidator of(Enum<?> mode) throws LoadingException {
+    @SneakyThrows({IOException.class, ValidatorParsingException.class})
+    public static BusinessCertificateValidator of(Enum<?> mode) {
         return of(pathFromEnum(mode));
     }
 
@@ -51,9 +56,12 @@ public class BusinessCertificateValidator {
      *
      * @param modeString Mode as string.
      * @return Validator for validation of business certificates.
-     * @throws LoadingException when loading of validator is unsuccessful.
+     * @throws IOException or
+     * @throws ValidatorParsingException or
+     * @throws CertificateValidationException when loading of validator is unsuccessful.
      */
-    public static BusinessCertificateValidator of(String modeString) throws LoadingException {
+    @SneakyThrows({IOException.class, ValidatorParsingException.class, CertificateValidationException.class})
+    public static BusinessCertificateValidator of(String modeString) {
         String path = Mode.of(modeString)
                 .map(BusinessCertificateValidator::pathFromEnum)
                 .orElse(modeString);
@@ -79,13 +87,13 @@ public class BusinessCertificateValidator {
      * Loads the certificate validator by using the path to the recipe file found in class path.
      *
      * @param path Path to recipe file in class path.
-     * @throws LoadingException when loading of validator is unsuccessful.
+     * @throws IllegalStateException when loading of validator is unsuccessful.
      */
-    private BusinessCertificateValidator(String path) throws LoadingException {
+    private BusinessCertificateValidator(String path) {
         try (InputStream inputStream = getClass().getResourceAsStream(path)) {
             this.validator = ValidatorLoader.newInstance().build(inputStream);
         } catch (IOException | ValidatorParsingException e) {
-            throw new LoadingException("Unable to load certificate validator.", e);
+            throw new IllegalStateException("Unable to load certificate validator", e);
         }
     }
 
@@ -93,13 +101,13 @@ public class BusinessCertificateValidator {
      * Validate certificate.
      *
      * @param certificate Certificate as a {@link X509Certificate} object.
-     * @throws Exception validation failed.
+     * @throws IllegalStateException validation failed.
      */
-    public void validate(X509Certificate certificate) throws Exception {
+    public void validate(X509Certificate certificate) {
         try {
             validator.validate(certificate);
         } catch (CertificateValidationException e) {
-            throw new Exception(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
+            throw new IllegalStateException(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
         }
     }
 
@@ -107,13 +115,13 @@ public class BusinessCertificateValidator {
      * Validate certificate.
      *
      * @param certificate Certificate as a byte array.
-     * @throws Exception validation failed.
+     * @throws IllegalStateException validation failed.
      */
-    public void validate(byte[] certificate) throws Exception {
+    public void validate(byte[] certificate) {
         try {
             validator.validate(certificate);
         } catch (CertificateValidationException e) {
-            throw new Exception(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
+            throw new IllegalStateException(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
         }
     }
 
@@ -121,25 +129,13 @@ public class BusinessCertificateValidator {
      * Validate certificate.
      *
      * @param inputStream Certificate from an {@link InputStream}.
-     * @throws Exception validation failed.
+     * @throws IllegalStateException if validation failed.
      */
-    public void validate(InputStream inputStream) throws Exception {
+    public void validate(InputStream inputStream) {
         try {
             validator.validate(inputStream);
         } catch (CertificateValidationException e) {
-            throw new Exception(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
-        }
-    }
-
-    public static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
-
-    public static class LoadingException extends RuntimeException {
-        public LoadingException(String message, Throwable cause) {
-            super(message, cause);
+            throw new IllegalStateException(VALIDATION_OF_BUSINESS_CERTIFICATE_FAILED, e);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidator.java
@@ -26,10 +26,9 @@ public class BusinessCertificateValidator {
      *
      * @param mode One of the modes part of this package.
      * @return Validator for validation of business certificates.
-     * @throws IOException               or
-     * @throws ValidatorParsingException when loading of validator is unsuccessful.
+     * @throws IllegalStateException when loading of validator is unsuccessful.
      */
-    @SneakyThrows({IOException.class, ValidatorParsingException.class})
+    @SneakyThrows({IllegalStateException.class})
     public static BusinessCertificateValidator of(Mode mode) {
         return of((Enum<Mode>) mode);
     }
@@ -42,10 +41,9 @@ public class BusinessCertificateValidator {
      *
      * @param mode Some enum annotated with {@link RecipePath}
      * @return Validator for validation of business certificates.
-     * @throws IOException               or
-     * @throws ValidatorParsingException when loading of validator is unsuccessful.
+     * @throws IllegalStateException when loading of validator is unsuccessful.
      */
-    @SneakyThrows({IOException.class, ValidatorParsingException.class})
+    @SneakyThrows({IllegalStateException.class})
     public static BusinessCertificateValidator of(Enum<?> mode) {
         return of(pathFromEnum(mode));
     }
@@ -56,11 +54,9 @@ public class BusinessCertificateValidator {
      *
      * @param modeString Mode as string.
      * @return Validator for validation of business certificates.
-     * @throws IOException                    or
-     * @throws ValidatorParsingException      or
-     * @throws CertificateValidationException when loading of validator is unsuccessful.
+     * @throws IllegalStateException when loading of validator is unsuccessful.
      */
-    @SneakyThrows({IOException.class, ValidatorParsingException.class, CertificateValidationException.class})
+    @SneakyThrows({IllegalStateException.class})
     public static BusinessCertificateValidator of(String modeString) {
         String path = Mode.of(modeString)
                 .map(BusinessCertificateValidator::pathFromEnum)

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateAsiceImpl.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateAsiceImpl.java
@@ -39,7 +39,7 @@ public class CreateAsiceImpl implements CreateAsice {
         try {
             asicWriter.sign(signatureHelper);
         } catch (IOException e) {
-            throw new RuntimeException("Could not sign ASiC-E!", e);
+            throw new IllegalStateException("Could not sign ASiC-E!", e);
         }
     }
 
@@ -48,7 +48,7 @@ public class CreateAsiceImpl implements CreateAsice {
         try (InputStream inputStream = new BufferedInputStream(attachable.getResource().getInputStream())) {
             asicWriter.add(inputStream, attachable.getFilename(), MimeType.forString(attachable.getMimeType()));
         } catch (IOException e) {
-            throw new RuntimeException("Could not add manifest to ASiC-E!", e);
+            throw new IllegalStateException("Could not add manifest to ASiC-E!", e);
         }
     }
 

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateAsiceImpl.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateAsiceImpl.java
@@ -1,6 +1,7 @@
 package no.difi.meldingsutveksling.dpi.client.internal;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.difi.asic.*;
 import no.difi.meldingsutveksling.dpi.client.domain.AsicEAttachable;
@@ -38,7 +39,7 @@ public class CreateAsiceImpl implements CreateAsice {
         try {
             asicWriter.sign(signatureHelper);
         } catch (IOException e) {
-            throw new Exception("Could not sign ASiC-E!", e);
+            throw new RuntimeException("Could not sign ASiC-E!", e);
         }
     }
 
@@ -47,22 +48,13 @@ public class CreateAsiceImpl implements CreateAsice {
         try (InputStream inputStream = new BufferedInputStream(attachable.getResource().getInputStream())) {
             asicWriter.add(inputStream, attachable.getFilename(), MimeType.forString(attachable.getMimeType()));
         } catch (IOException e) {
-            throw new Exception("Could not add manifest to ASiC-E!", e);
+            throw new RuntimeException("Could not add manifest to ASiC-E!", e);
         }
     }
 
+    @SneakyThrows({IOException.class})
     private AsicWriter getAsicWriter(OutputStream outputStream) {
-        try {
             return AsicWriterFactory.newFactory(SignatureMethod.XAdES)
                     .newContainer(outputStream);
-        } catch (IOException e) {
-            throw new Exception("Could not create ASiC-E writer!", e);
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateCMSDocument.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateCMSDocument.java
@@ -10,6 +10,7 @@ import org.bouncycastle.cms.CMSEnvelopedDataStreamGenerator;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
 import org.bouncycastle.cms.jcajce.JceKeyTransRecipientInfoGenerator;
+import org.bouncycastle.crypto.CryptoException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.OutputEncryptor;
 
@@ -40,15 +41,9 @@ public class CreateCMSDocument {
             IOUtils.copyLarge(inputStream, open);
             open.close();
         } catch (CertificateEncodingException e) {
-            throw new Exception("Something is wrong with the business certificate", e);
+            throw new IllegalArgumentException("Something is wrong with the business certificate", e);
         } catch (CMSException | IOException e) {
-            throw new Exception("Couldn't create Cryptographic Message Syntax for document package!", e);
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
+            throw new IllegalStateException("Couldn't create Cryptographic Message Syntax for document package!", e);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateCmsEncryptedAsice.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateCmsEncryptedAsice.java
@@ -6,10 +6,12 @@ import no.difi.meldingsutveksling.dpi.client.domain.CmsEncryptedAsice;
 import no.difi.meldingsutveksling.dpi.client.domain.Shipment;
 import no.difi.move.common.io.InMemoryWithTempFileFallbackResource;
 import no.difi.move.common.io.InMemoryWithTempFileFallbackResourceFactory;
+import org.bouncycastle.cms.CMSException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.cert.CertificateEncodingException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,7 +31,7 @@ public class CreateCmsEncryptedAsice {
         try (InputStream inputStream = asic.getInputStream(); OutputStream outputStream = cms.getOutputStream()) {
             createCMS.createCMS(inputStream, outputStream, shipment.getReceiverBusinessCertificate());
         } catch (IOException e) {
-            throw new Exception("CMS encryption failed!", e);
+            throw new IllegalStateException("CMS encryption failed!", e);
         }
         return cms;
     }
@@ -40,14 +42,8 @@ public class CreateCmsEncryptedAsice {
         try (OutputStream outputStream = asic.getOutputStream()) {
             createASiCE.createAsice(shipment, outputStream);
         } catch (IOException e) {
-            throw new Exception("Creating ASiC-E failed!", e);
+            throw new IllegalArgumentException("Creating ASiC-E failed!", e);
         }
         return asic;
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateJWT.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateJWT.java
@@ -28,7 +28,7 @@ public class CreateJWT {
         try {
             return keyPair.getBusinessCertificate().getX509Certificate().getEncoded();
         } catch (CertificateEncodingException e) {
-            throw new Exception("Couldn't get encoded certificate!", e);
+            throw new IllegalArgumentException("Couldn't get encoded certificate!", e);
         }
     }
 
@@ -42,18 +42,12 @@ public class CreateJWT {
         try {
             jwsObject.sign(jwsSigner);
         } catch (JOSEException e) {
-            throw new Exception("Signing failed!", e);
+            throw new IllegalStateException("Signing failed!", e);
         }
     }
 
     private JWSObject getJwsObject(Map<String, Object> sbd) {
         Payload payload = new Payload(new JSONObject(sbd));
         return new JWSObject(jwsHeader, payload);
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateManifest.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateManifest.java
@@ -28,7 +28,7 @@ public class CreateManifest {
         try {
             m.afterPropertiesSet();
         } catch (java.lang.Exception e) {
-            throw new CreateManifest.Exception("createJaxb2Marshaller failed!", e);
+            throw new IllegalStateException("createJaxb2Marshaller failed!", e);
         }
         return m;
     }
@@ -41,17 +41,11 @@ public class CreateManifest {
             return new Manifest(new ByteArrayResource(manifestStream.toByteArray()));
         } catch (MarshallingFailureException e) {
             if (e.getMostSpecificCause() instanceof SAXParseException) {
-                throw new Exception("Kunne ikke validere generert Manifest XML. Sjekk at alle påkrevde input er satt og ikke er null",
+                throw new IllegalArgumentException("Kunne ikke validere generert Manifest XML. Sjekk at alle påkrevde input er satt og ikke er null",
                         e.getMostSpecificCause());
             }
 
             throw e;
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateParcelFingerprint.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/CreateParcelFingerprint.java
@@ -18,13 +18,7 @@ public class CreateParcelFingerprint {
                     .setDigestMethod("http://www.w3.org/2001/04/xmlenc#sha256")
                     .setDigestValue(Base64.getEncoder().encodeToString(DigestUtils.sha256(inputStream)));
         } catch (IOException e) {
-            throw new Exception("Failed to create parcel fingerprint", e);
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
+            throw new IllegalStateException("Failed to create parcel fingerprint", e);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/GetConsumerOrg.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/GetConsumerOrg.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import no.difi.meldingsutveksling.domain.Iso6523;
 import no.difi.meldingsutveksling.dpi.client.domain.sbd.Avsender;
 
+import java.util.MissingFormatArgumentException;
+import java.util.MissingResourceException;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -14,14 +16,8 @@ public class GetConsumerOrg {
                 .flatMap(p -> Optional.ofNullable(p.getVirksomhetsidentifikator()))
                 .flatMap(p -> Optional.ofNullable(p.getValue()))
                 .map(Iso6523::parse)
-                .orElseThrow(() -> new Exception("Missing businessMessage.avsender.virksomhetsidentifikator.value!"));
+                .orElseThrow(() -> new IllegalStateException("Missing businessMessage.avsender.virksomhetsidentifikator.value!"));
 
         return iso6523.getOrganizationIdentifier();
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message) {
-            super(message);
-        }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/JsonDigitalPostSchemaValidator.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/JsonDigitalPostSchemaValidator.java
@@ -5,6 +5,7 @@ import net.jimblackler.jsonschemafriend.Schema;
 import net.jimblackler.jsonschemafriend.ValidationException;
 import net.jimblackler.jsonschemafriend.Validator;
 
+import java.lang.instrument.IllegalClassFormatException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -20,25 +21,14 @@ public class JsonDigitalPostSchemaValidator {
 
     private Schema getSchema(String type) {
         return Optional.ofNullable(schemaMap.get(type))
-                .orElseThrow(() -> new Exception(String.format("Unknown standardBusinessDocument.standardBusinessDocumentHeader.documentIdentification.type = %s. Expecting one of %s", type, String.join(",", schemaMap.keySet()))));
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Unknown standardBusinessDocument.standardBusinessDocumentHeader.documentIdentification.type = %s. Expecting one of %s", type, String.join(",", schemaMap.keySet()))));
     }
 
     private void validate(Object document, Schema schema) {
         try {
             validator.validate(schema, document);
         } catch (ValidationException e) {
-            throw new Exception("Validation of Digital Post SBD failed!", e);
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-
-        public Exception(String message) {
-            super(message);
-        }
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
+            throw new IllegalStateException("Validation of Digital Post SBD failed!", e);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/KeyPairProvider.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/KeyPairProvider.java
@@ -1,6 +1,7 @@
 package no.difi.meldingsutveksling.dpi.client.internal;
 
 import lombok.RequiredArgsConstructor;
+import no.difi.certvalidator.api.CertificateValidationException;
 import no.difi.meldingsutveksling.dpi.client.domain.BusinessCertificate;
 import no.difi.meldingsutveksling.dpi.client.domain.KeyPair;
 import no.difi.move.common.cert.KeystoreProvider;
@@ -9,6 +10,7 @@ import no.difi.move.common.config.KeystoreProperties;
 
 import java.security.*;
 import java.security.cert.Certificate;
+import java.util.MissingFormatArgumentException;
 
 @RequiredArgsConstructor
 public class KeyPairProvider {
@@ -31,7 +33,7 @@ public class KeyPairProvider {
         try {
             return KeystoreProvider.loadKeyStore(properties);
         } catch (KeystoreProviderException e) {
-            throw new Exception("Couldn't load keystore!", e);
+            throw new IllegalStateException("Couldn't load keystore!", e);
         }
     }
 
@@ -49,7 +51,7 @@ public class KeyPairProvider {
         try {
             return keyStore.getCertificateChain(properties.getAlias());
         } catch (KeyStoreException e) {
-            throw new Exception("Kunne ikke hente sertifikatkjede fra KeyStore. Er KeyStore initialisiert?", e);
+            throw new IllegalStateException("Kunne ikke hente sertifikatkjede fra KeyStore. Er KeyStore initialisiert?", e);
         }
     }
 
@@ -58,25 +60,15 @@ public class KeyPairProvider {
 
             Key key = keyStore.getKey(properties.getAlias(), properties.getPassword().toCharArray());
             if (!(key instanceof PrivateKey)) {
-                throw new Exception("Kunne ikke hente privatnøkkel fra KeyStore. Forventet å få en PrivateKey, fikk " + key.getClass().getCanonicalName());
+                throw new IllegalStateException("Kunne ikke hente privatnøkkel fra KeyStore. Forventet å få en PrivateKey, fikk " + key.getClass().getCanonicalName());
             }
             return (PrivateKey) key;
         } catch (KeyStoreException e) {
-            throw new Exception("Kunne ikke hente privatnøkkel fra KeyStore. Er KeyStore initialisiert?", e);
+            throw new IllegalStateException("Kunne ikke hente privatnøkkel fra KeyStore. Er KeyStore initialisiert?", e);
         } catch (NoSuchAlgorithmException e) {
-            throw new Exception("Kunne ikke hente privatnøkkel fra KeyStore. Verifiser at nøkkelen er støttet på plattformen", e);
+            throw new IllegalStateException("Kunne ikke hente privatnøkkel fra KeyStore. Verifiser at nøkkelen er støttet på plattformen", e);
         } catch (UnrecoverableKeyException e) {
-            throw new Exception("Kunne ikke hente privatnøkkel fra KeyStore. Sjekk at passordet er riktig.", e);
-        }
-    }
-
-    private static class Exception extends RuntimeException {
-        public Exception(String message) {
-            super(message);
-        }
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
+            throw new IllegalStateException("Kunne ikke hente privatnøkkel fra KeyStore. Sjekk at passordet er riktig.", e);
         }
     }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/LocalDirectoryCorner2Client.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/LocalDirectoryCorner2Client.java
@@ -37,7 +37,7 @@ public class LocalDirectoryCorner2Client implements Corner2Client {
         try {
             Files.write(getPath(base, "jwt"), jwt.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
-            throw new Exception("Couldn't save file!", e);
+            throw new IllegalStateException("Couldn't save file!", e);
         }
     }
 
@@ -45,7 +45,7 @@ public class LocalDirectoryCorner2Client implements Corner2Client {
         try (InputStream is = cmsEncryptedAsice.getResource().getInputStream()) {
             Files.copy(is, getPath(base, "asic.cms"), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new Exception("Couldn't save file!", e);
+            throw new IllegalStateException("Couldn't save file!", e);
         }
     }
 
@@ -55,7 +55,7 @@ public class LocalDirectoryCorner2Client implements Corner2Client {
                     String.format("%s-%s.%s", base, properties.getAsice().getType(), postfix));
             return targetFile.toPath();
         } catch (MalformedURLException e) {
-            throw new Exception("Malformed URL", e);
+            throw new IllegalStateException("Malformed URL", e);
         }
     }
 
@@ -79,9 +79,4 @@ public class LocalDirectoryCorner2Client implements Corner2Client {
         throw new UnsupportedOperationException();
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/UnpackJWT.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/internal/UnpackJWT.java
@@ -29,7 +29,7 @@ public class UnpackJWT {
         try {
             Assert.state(jwsObject.verify(getVerifier(jwsObject)), "Verifying JWT failed!");
         } catch (IllegalStateException | JOSEException e) {
-            throw new Exception("Verifying JWT failed!", e);
+            throw new IllegalStateException("Verifying JWT failed!", e);
         }
     }
 
@@ -41,7 +41,7 @@ public class UnpackJWT {
         try {
             return JWSObject.parse(jwt);
         } catch (ParseException e) {
-            throw new Exception("Parsing JWT failed!", e);
+            throw new IllegalStateException("Parsing JWT failed!", e);
         }
     }
 
@@ -58,14 +58,8 @@ public class UnpackJWT {
                     .findFirst()
                     .orElseThrow(() -> new DpiException("Can not find signing certificate!", Blame.SERVER));
         } catch (ParseException e) {
-            throw new Exception("Can parse signing certificate!", e);
+            throw new IllegalStateException("Can parse signing certificate!", e);
         }
     }
 
-    private static class Exception extends RuntimeException {
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/AsicParser.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/AsicParser.java
@@ -20,7 +20,7 @@ public class AsicParser {
             }
 
         } catch (IOException e) {
-            throw new Exception("Couldn't parse ASICe", e);
+            throw new IllegalStateException("Couldn't parse ASICe", e);
         }
     }
 
@@ -29,10 +29,4 @@ public class AsicParser {
         void onFile(String filename, InputStream inputStream);
     }
 
-    private static class Exception extends RuntimeException {
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/DecryptCMSDocument.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/DecryptCMSDocument.java
@@ -18,7 +18,7 @@ public class DecryptCMSDocument {
         try {
             return getRecipientInformation(encrypted).getContentStream(recipient).getContentStream();
         } catch (CMSException | IOException e) {
-            throw new Exception("Couldn't decrypt CMS", e);
+            throw new IllegalStateException("Couldn't decrypt CMS", e);
         }
     }
 
@@ -26,24 +26,15 @@ public class DecryptCMSDocument {
         return getParser(encrypted).getRecipientInfos().getRecipients()
                 .stream()
                 .findFirst()
-                .orElseThrow(() -> new Exception("No recipients in CMS document."));
+                .orElseThrow(() -> new IllegalArgumentException("No recipients in CMS document."));
     }
 
     private CMSEnvelopedDataParser getParser(InputStream encrypted) {
         try {
             return new CMSEnvelopedDataParser(encrypted);
         } catch (CMSException | IOException e) {
-            throw new Exception("Couldn't create CMS parser", e);
+            throw new IllegalStateException("Couldn't create CMS parser", e);
         }
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message) {
-            super(message);
-        }
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/InMemoryDocumentStorage.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/InMemoryDocumentStorage.java
@@ -31,7 +31,7 @@ public class InMemoryDocumentStorage implements DocumentStorage {
         try {
             return IOUtils.toByteArray(inputStream);
         } catch (IOException e) {
-            throw new Exception("Couldn't read all bytes", e);
+            throw new IllegalStateException("Couldn't read all bytes", e);
         }
     }
 
@@ -39,10 +39,4 @@ public class InMemoryDocumentStorage implements DocumentStorage {
         return data.getOrDefault(messageId, new HashMap<>());
     }
 
-    private static class Exception extends RuntimeException {
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ManifestParser.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ManifestParser.java
@@ -31,13 +31,8 @@ public class ManifestParser {
         try (InputStream inputStream = resource.getInputStream()) {
             return (SDPManifest) marshaller.unmarshal(new StreamSource(inputStream));
         } catch (IOException e) {
-            throw new Exception("Failed to parse SDPManifest!", e);
+            throw new IllegalStateException("Failed to parse SDPManifest!", e);
         }
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ParcelParser.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ParcelParser.java
@@ -50,7 +50,7 @@ public class ParcelParser {
 
     private Document getDocument(Map<String, Document> documents, String filename) {
         return Optional.ofNullable(documents.get(filename))
-                .orElseThrow(() -> new Exception(String.format("No file named '%s' in ASICe!", filename)));
+                .orElseThrow(() -> new IllegalArgumentException(String.format("No file named '%s' in ASICe!", filename)));
     }
 
     private Document getDocument(Map<String, Document> documents, SDPDokument sdpDokument) {
@@ -75,9 +75,4 @@ public class ParcelParser {
                 .setResource(resource);
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message) {
-            super(message);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ShipmentFactory.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/ShipmentFactory.java
@@ -34,7 +34,7 @@ public class ShipmentFactory {
         try (InputStream inputStream = input.getReceiverCertificate().getInputStream()) {
             return BusinessCertificate.of(IOUtils.toByteArray(inputStream));
         } catch (IOException e) {
-            throw new Exception("Couldn't get receiver certificate!", e);
+            throw new IllegalStateException("Couldn't get receiver certificate!", e);
         }
     }
 
@@ -55,9 +55,4 @@ public class ShipmentFactory {
                 .setMimeType(fileExtensionMapper.getMimetype(resource));
     }
 
-    private static class Exception extends RuntimeException {
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidatorTest.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidatorTest.java
@@ -30,6 +30,6 @@ class BusinessCertificateValidatorTest {
 
     @Test()
     void receiptNotFound() {
-        Assertions.assertThrows(IOException.class, () -> BusinessCertificateValidator.of("/invalid-path.xml"));
+        Assertions.assertThrows(IllegalStateException.class, () -> BusinessCertificateValidator.of("/invalid-path.xml"));
     }
 }

--- a/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidatorTest.java
+++ b/dpi-client/src/test/java/no/difi/meldingsutveksling/dpi/client/internal/BusinessCertificateValidatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.security.cert.X509Certificate;
 
 class BusinessCertificateValidatorTest {
@@ -29,6 +30,6 @@ class BusinessCertificateValidatorTest {
 
     @Test()
     void receiptNotFound() {
-        Assertions.assertThrows(BusinessCertificateValidator.LoadingException.class, () -> BusinessCertificateValidator.of("/invalid-path.xml"));
+        Assertions.assertThrows(IOException.class, () -> BusinessCertificateValidator.of("/invalid-path.xml"));
     }
 }


### PR DESCRIPTION
Blei fleire generelle exceptions av typen runtime exceptions... Kanskje det hadde vore betre å lage eigne spesifikke exceptions som extender RuntimeException så det er tydeligare kva dei faktisk betyr. Brukte sneakythrows på nokre, men ganske få sidan kommentarane er nyttige å ha med. 