### PR TITLE
fix: MOVE-2894: Use FIKS keystore for decrypting

### DIFF
--- a/fiks-meldingsformidler/src/main/java/no/difi/meldingsutveksling/ks/svarinn/SvarInnFileDecryptor.java
+++ b/fiks-meldingsformidler/src/main/java/no/difi/meldingsutveksling/ks/svarinn/SvarInnFileDecryptor.java
@@ -1,17 +1,21 @@
 package no.difi.meldingsutveksling.ks.svarinn;
 
-import lombok.RequiredArgsConstructor;
+import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
 import no.difi.meldingsutveksling.dokumentpakking.service.DecryptCMSDocument;
 import no.difi.move.common.cert.KeystoreHelper;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class SvarInnFileDecryptor {
 
     private final DecryptCMSDocument decryptCMSDocument;
     private final KeystoreHelper keystoreHelper;
+
+    public SvarInnFileDecryptor(DecryptCMSDocument decryptCMSDocument, IntegrasjonspunktProperties properties) {
+        this.decryptCMSDocument = decryptCMSDocument;
+        this.keystoreHelper = new KeystoreHelper(properties.getFiks().getKeystore());
+    }
 
     public Resource decrypt(Resource encrypted) {
         return decryptCMSDocument.decrypt(DecryptCMSDocument.Input.builder()


### PR DESCRIPTION
- Use difi.move.fiks.keystore for decrypting SvarInn messages.