### PR TITLE
MOVE-3107 Fikset sjelden feilsituasjon i DPI fører til at integrasjon…

### DIFF
--- a/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/DpiClientImpl.java
+++ b/dpi-client/src/main/java/no/difi/meldingsutveksling/dpi/client/DpiClientImpl.java
@@ -74,7 +74,7 @@ public class DpiClientImpl implements DpiClient {
     public Flux<ReceivedMessage> getMessages(GetMessagesInput input) {
         return corner2Client.getMessages(input)
                 .map(messageUnwrapper::unwrap)
-                .onErrorContinue((e, i) -> log.warn("Unwrapping message failed: {} {}", e, i));
+                .onErrorContinue(IllegalStateException.class, (e, i) -> log.warn("Unwrapping message failed: {} {}", e, i));
     }
 
     @Override


### PR DESCRIPTION
Fikset sjelden feilsituasjon i DPI fører til at integrasjonspunktet kjem i ei tilstand der ein ikkje klarer å hente inn kvitteringar.

Jobben som hentar kvitteringar for DPI henter ein bunke kvitteringar og validerer desse løpande. Dette blir gjort med strømming slik at ein les inn kvitteringar og validerer dei etterkvart (istadenfor å lese inn alt først).

Feilhandteringa ved validering av kvittering håndterte alle feil ved å ignorere dei og fortsette til neste kvittering. Dette gjaldt også nettverksbrot o.l. Ved nettverksbrot er det ikkje lenger mulig å lese inn neste kvittering, men når feilen først var ignorert prøvde ein like fullt å lese inn neste kvittering. I dette litt sære tilfellet vart tråden som lagrar dei innleste og validerte kvitteringane til database ståande og vente på neste kvittering, som aldri kunne komme pga. nettverksbrotet og som aldri feila pga. feilen som vart ignorert. Ved å begrense feilhandteringa til berre å ignorere faktiske valideringsfeil unngår ein feilsituasjonen.