### PR TITLE
feat: MOVE-3179: Upgrade container dependencies

### DIFF
--- a/integrasjonspunkt/Dockerfile
+++ b/integrasjonspunkt/Dockerfile
@@ -9,7 +9,7 @@ ENV APP_DIR=/opt/integrasjonspunkt \
     KEYSTOREFILE=${JAVA_HOME}/lib/security/cacerts \
     KEYSTOREPASS=changeit
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
     curl \
     openssl  && \


### PR DESCRIPTION
- Add "apt-get upgrade -y" instruction in Dockerfile, to remove vulnerabilities caused by outdated dependencies in the container OS.