### PR TITLE
FiksMapper: if configured use orgNo from KorrespondansePart in 'svarSendesTil'

### DIFF
--- a/common-spring/src/main/java/no/difi/meldingsutveksling/config/FiksConfig.java
+++ b/common-spring/src/main/java/no/difi/meldingsutveksling/config/FiksConfig.java
@@ -67,6 +67,7 @@ public class FiksConfig {
         private Map<String, FiksCredentials> paaVegneAv = Maps.newHashMap();
         @NotNull
         private Integer defaultTtlHours;
+        private boolean svarSendesTilKorrespondansepart;
     }
 
     @Data

--- a/fiks-meldingsformidler/src/main/java/no/difi/meldingsutveksling/ks/mapping/FiksMapper.java
+++ b/fiks-meldingsformidler/src/main/java/no/difi/meldingsutveksling/ks/mapping/FiksMapper.java
@@ -262,9 +262,12 @@ public class FiksMapper {
         return x == null ? 0 : x.intValueExact();
     }
 
-    private Adresse mottakerFrom(Korrespondansepart kp, String orgnr) {
+    private Adresse mottakerFrom(Korrespondansepart kp, String overrideKorrespondansePartOrgNo) {
         return Adresse.builder()
-                .withDigitalAdresse(OrganisasjonDigitalAdresse.builder().withOrgnr(orgnr).build())
+                .withDigitalAdresse(OrganisasjonDigitalAdresse.builder().withOrgnr(
+                        properties.getFiks().getUt().isSvarSendesTilKorrespondansepart()
+                        ? kp.getAdministrativEnhet()
+                        : overrideKorrespondansePartOrgNo).build())
                 .withPostAdresse(PostAdresse.builder()
                         .withNavn(kp.getKorrespondansepartNavn())
                         .withAdresse1(String.join(" ", kp.getPostadresse()))

--- a/integrasjonspunkt/src/main/resources/config/application.properties
+++ b/integrasjonspunkt/src/main/resources/config/application.properties
@@ -155,6 +155,7 @@ difi.move.fiks.ut.endpointUrl=https://test.svarut.ks.no/tjenester/forsendelseser
 difi.move.fiks.ut.kun-digital-levering=false
 difi.move.fiks.ut.upload-size-limit=1GB
 difi.move.fiks.ut.default-ttl-hours=${difi.move.nextmove.default-ttl-hours}
+difi.move.fiks.ut.svar-sendes-til-korrespondansepart=false
 
 # FIKS IO
 difi.move.fiks.io.host=io.fiks.test.ks.no


### PR DESCRIPTION
- Most if not all sak/arkiv systems (elements, p360, websak) use the organisation number in the 'svarSendesTil' part of the SvarInn XML to determine where to send a response. If the noark5-ish arkivmelding contains a 'Avsender' KorrespondansePart the organisation number specified there should be respected. The SvarInn XML differentiates between who sends a message and whom the reply should go to - this change _is not synonymous to sending messages on behalf of others!_.