### PR TITLE
Feature move 3429 forbedre logging av feil når sletting av filer i integrasjonspunktet feilar

### DIFF
--- a/common/src/main/java/no/difi/meldingsutveksling/TmpFile.java
+++ b/common/src/main/java/no/difi/meldingsutveksling/TmpFile.java
@@ -50,7 +50,7 @@ public class TmpFile {
         try {
             FileUtils.forceDelete(getFile());
         } catch (IOException e) {
-            log.warn(String.format("Error deleting tmp file %s - make sure streams are closed", getFullPath()), e);
+            log.warn(String.format("Error deleting files in TmpFile.delete() tmp file %s - make sure streams are closed", getFullPath()), e);
         }
     }
 

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/NextMoveSender.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/NextMoveSender.java
@@ -55,7 +55,7 @@ public class NextMoveSender {
         try {
             messagePersister.delete(msg.getMessageId());
         } catch (IOException e) {
-            log.warn("Error deleting files from message with id={}", msg.getMessageId(), e);
+            log.warn("Error deleting files in NextMoveSender.send() from message with id={}", msg.getMessageId(), e);
         }
 
         messageRepo.findIdByMessageId(msg.getMessageId()).ifPresent(

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageInService.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageInService.java
@@ -100,7 +100,7 @@ public class NextMoveMessageInService {
         try {
             cryptoMessagePersister.delete(messageId);
         } catch (IOException e) {
-            log.warn("Error deleting files from message with id={}", messageId, e);
+            log.warn("Error deleting files in NextMoveMessageInService.deleteMessage() from message with id={}", messageId, e);
         }
 
         messageRepo.delete(message);

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageService.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/NextMoveMessageService.java
@@ -87,7 +87,7 @@ public class NextMoveMessageService {
         try {
             messagePersister.delete(messageId);
         } catch (IOException e) {
-            log.warn("Error deleting files from message with id={}", messageId, e);
+            log.warn("Error deleting files in NextMoveMessageService.deleteMessage() from message with id={}", messageId, e);
         }
 
         messageRepo.findIdByMessageId(messageId).ifPresent(

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/TimeToLiveExpiredHandler.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/nextmove/v2/TimeToLiveExpiredHandler.java
@@ -42,7 +42,7 @@ public class TimeToLiveExpiredHandler {
                     try {
                         messagePersister.delete(messageId);
                     } catch (IOException e) {
-                        log.error(markerFrom(conversation), "Could not delete files for expired message {}", messageId, e);
+                        log.warn(markerFrom(conversation), "Error deleting files in TimeToLiveExpiredHandler.setExpired() for expired message {}", messageId, e);
                     }
 
                     businessMessageFileRepository.deleteFilesByMessageId(id);

--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/noarkexchange/IntegrajonspunktReceiveImpl.java
@@ -102,7 +102,7 @@ public class IntegrajonspunktReceiveImpl {
             try {
                 messagePersister.delete(sbd.getMessageId());
             } catch (IOException e) {
-                log.warn(markerFrom(sbd), "Could not delete files for expired message {}", sbd.getMessageId(), e);
+                log.warn(markerFrom(sbd), "Error deleting files in IntegrajonspunktReceiveImpl.forwardToNoarkSystem() for expired message {}", sbd.getMessageId(), e);
             }
             return;
         }
@@ -169,7 +169,7 @@ public class IntegrajonspunktReceiveImpl {
                 try {
                     messagePersister.delete(sbd.getMessageId());
                 } catch (IOException e) {
-                    log.warn(String.format("Unable to delete files for message with id=%s", sbd.getMessageId()), e);
+                    log.warn(String.format("Error deleting files in IntegrajonspunktReceiveImpl.forwardToNoarkSystemAndSendReceipts() for message with id=%s", sbd.getMessageId()), e);
                 }
             } else {
                 Audit.error(String.format("Unexpected response from archive for message [id=%s]", sbd.getMessageId()), markerFrom(response));

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <properties>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <commons.io.version>2.11.0</commons.io.version>
+        <commons.io.version>2.13.0</commons.io.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.text.version>1.10.0</commons.text.version>
         <sikker-digital-post-klient.version>6.4.RC1</sikker-digital-post-klient.version>


### PR DESCRIPTION
Kan vera loggingen blir for omstendeleg sånn som den er satt opp no med navnet på fil og metode som feilar, kan endrast kjapt om det trengs.