### PR TITLE
fix: Clear MDC after status update

### DIFF
--- a/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/status/StatusPolling.java
+++ b/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/status/StatusPolling.java
@@ -7,6 +7,7 @@ import no.difi.meldingsutveksling.api.StatusStrategy;
 import no.difi.meldingsutveksling.config.IntegrasjonspunktProperties;
 import no.difi.meldingsutveksling.nextmove.ConversationStrategyFactory;
 import no.difi.meldingsutveksling.receipt.StatusStrategyFactory;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -67,6 +68,8 @@ public class StatusPolling {
             strategy.checkStatus(conversations);
         } catch (Exception e) {
             log.error(format("Exception during receipt polling for %s", si), e);
+        } finally {
+            MDC.clear();
         }
     }
 }


### PR DESCRIPTION
I dag legges `correlation_id` på [MDC i `DefaultConverstaionService`](https://github.com/felleslosninger/efm-integrasjonspunkt/blob/2a81a78dbe8cff5366e97054f6a48d5da323ab59/integrasjonspunkt/src/main/java/no/difi/meldingsutveksling/status/DefaultConversationService.java#L104), men den fjernes aldri. Dette fører til at den samme `correlation_id` feilaktig logges i sammenhenger den ikke skal, noe som vanskeliggjør feilsøking.

I bildet under settes status på en melding til `LEST` før den samme `correlation_id` dukker opp tilknyttet logglinjer den ikke skal ha et forhold til
![Correlation_id_feil_logglinje](https://github.com/felleslosninger/efm-integrasjonspunkt/assets/32869572/3c8c03a1-ab13-4f00-9629-51746d6a95d9)

Denne fiksen tømmer MDC-en etter hvert kall på `checkStatus`