### PR TITLE
feat: MOVE-3477: Transfer arkivmelding receipt conf

### DIFF
--- a/integrasjonspunkt/src/main/resources/config/application-production.properties
+++ b/integrasjonspunkt/src/main/resources/config/application-production.properties
@@ -47,4 +47,7 @@ difi.move.dpi.mpcId=no.difi.move.integrasjonspunkt
 # DPV
 difi.move.dpv.endpointUrl=https://www.altinn.no/ServiceEngineExternal/CorrespondenceAgencyExternal.svc
 
+difi.move.arkivmelding.generate-receipts=false
+
 spring.config.import=optional:file:integrasjonspunkt-local.properties
+

--- a/integrasjonspunkt/src/main/resources/config/application-staging.properties
+++ b/integrasjonspunkt/src/main/resources/config/application-staging.properties
@@ -34,4 +34,7 @@ eureka.client.serviceUrl.defaultZone=https://qa-meldingsutveksling.difi.no/disco
 # DPI
 difi.move.dpi.endpoint=https://qaoffentlig.meldingsformidler.digipost.no/api/ebms
 
+difi.move.arkivmelding.generate-receipts=false
+
 spring.config.import=optional:file:integrasjonspunkt-local.properties
+


### PR DESCRIPTION
- The setting difi.move.arkivmelding.generate-receipts used to be overridden for staging and production profiles in cloud config. This change moves the override into the application, in an initiative to clean up the cloud configuration. Relates to MOVE-3440, MOVE-3469.