### PR TITLE
feat: MOVE-3734: Bump ActiveMQ version to 5.16.7

### DIFF
--- a/altinn-client/pom.xml
+++ b/altinn-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/altinnexchange/pom.xml
+++ b/altinnexchange/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>altinnexchange</artifactId>
-    <version>2.23.1</version>
+    <version>2.24.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/bestedu/pom.xml
+++ b/bestedu/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common-spring/pom.xml
+++ b/common-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/dokumentpakking/pom.xml
+++ b/dokumentpakking/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dokumentpakking</artifactId>
-    <version>2.23.1</version>
+    <version>2.24.0-SNAPSHOT</version>
 
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dpi-client/pom.xml
+++ b/dpi-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiks-meldingsformidler/pom.xml
+++ b/fiks-meldingsformidler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrasjonspunkt/pom.xml
+++ b/integrasjonspunkt/pom.xml
@@ -360,6 +360,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
+            <version>${activemq.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>error_prone_annotations</artifactId>

--- a/integrasjonspunkt/pom.xml
+++ b/integrasjonspunkt/pom.xml
@@ -3,14 +3,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integrasjonspunkt</artifactId>
-    <version>2.23.1</version>
+    <version>2.24.0-SNAPSHOT</version>
 
     <name>Meldingsutveksling Integrasjonspunkt</name>
 
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/nextmove/pom.xml
+++ b/nextmove/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/noarkexchange-ephorte/pom.xml
+++ b/noarkexchange-ephorte/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>noarkexchange-ephorte</artifactId>

--- a/noarkexchange-p360/pom.xml
+++ b/noarkexchange-p360/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>noarkexchange-p360</artifactId>

--- a/noarkexchange-template/pom.xml
+++ b/noarkexchange-template/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/noarkexchange-websak/pom.xml
+++ b/noarkexchange-websak/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>noarkexchange-websak</artifactId>

--- a/noarkexchange/pom.xml
+++ b/noarkexchange/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>noarkexchange</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>no.difi.meldingsutveksling</groupId>
     <artifactId>parent-pom</artifactId>
     <packaging>pom</packaging>
-    <version>2.23.1</version>
+    <version>2.24.0-SNAPSHOT</version>
     <name>Multiproject for meldingsutveksling</name>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     </repositories>
 
     <properties>
+        <activemq.version>5.16.7</activemq.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <commons.io.version>2.13.0</commons.io.version>

--- a/post-til-private/pom.xml
+++ b/post-til-private/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/post-til-virksomhet/pom.xml
+++ b/post-til-virksomhet/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>post-til-virksomhet</artifactId>
-    <version>2.23.1</version>
+    <version>2.24.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/service-registry-client/pom.xml
+++ b/service-registry-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>no.difi.meldingsutveksling</groupId>
-        <version>2.23.1</version>
+        <version>2.24.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Denne hotfix-en tek berre med endringa av ActiveMQ, samanlikna med development. Det hadde komme inn ein del anna der og. Kan derfor venta med 2.24.0? @Hmengland 