### PR TITLE
Use relative links for CSS files

### DIFF
--- a/integrasjonspunkt/src/main/resources/templates/conversations/index.html
+++ b/integrasjonspunkt/src/main/resources/templates/conversations/index.html
@@ -3,8 +3,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="utf-8"/>
-    <link th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" rel="stylesheet"/>
-    <link th:href="@{/webjars/font-awesome/css/all.min.css}" rel="stylesheet"/>
+    <link th:href="@{webjars/bootstrap/css/bootstrap.min.css}" rel="stylesheet"/>
+    <link th:href="@{webjars/font-awesome/css/all.min.css}" rel="stylesheet"/>
     <title>Conversations</title>
 </head>
 <body>


### PR DESCRIPTION
Fixes a bug where the web GUI has to be at root level for the styling to work.

For example, https://qa-meldingsutveksling.difi.no/integrasjonspunkt/digdir-leikanger/conversations is missing stylesheets because efm-integrasjonspunkt looks for stylesheets only at root level, not relative to the path of the website.