### PR TITLE
MOVE-update url in properties

### DIFF
--- a/integrasjonspunkt/src/main/resources/config/application-production.properties
+++ b/integrasjonspunkt/src/main/resources/config/application-production.properties
@@ -1,5 +1,7 @@
 ### Integrasjonspunkt properties ###
 
+difi.move.serviceregistryEndpoint=https://eformidling.no/adressetjeneste
+
 ## FIKS settings
 difi.move.fiks.inn.baseUrl=https://svarut.ks.no/tjenester/svarinn
 difi.move.fiks.ut.endpointUrl=https://svarut.ks.no/tjenester/forsendelseservice/ForsendelsesServiceV9

--- a/integrasjonspunkt/src/main/resources/config/application.properties
+++ b/integrasjonspunkt/src/main/resources/config/application.properties
@@ -21,7 +21,7 @@ spring.activemq.broker-url=${difi.activemq.broker-url}
 spring.activemq.user=${difi.activemq.user:}
 spring.activemq.password=${difi.activemq.password:}
 
-difi.move.serviceregistryEndpoint=https://meldingsutveksling.difi.no/serviceregistry
+difi.move.serviceregistryEndpoint=https://eformidling.dev/adressetjeneste
 
 ## ORGANIZATION
 #difi.move.org.number=
@@ -121,7 +121,7 @@ difi.move.dpi.pollingrate=10000
 
 ## FIKS settings
 difi.move.fiks.inn.enable=${difi.move.feature.enableDPF}
-difi.move.fiks.inn.baseUrl=https://svarut.ks.no/tjenester/svarinn
+difi.move.fiks.inn.baseUrl=https://test.svarut.ks.no/tjenester/svarinn
 difi.move.fiks.inn.process=urn:no:difi:profile:arkivmelding:administrasjon:ver1.0
 difi.move.fiks.inn.document-type=urn:no:difi:arkivmelding:xsd::arkivmelding
 difi.move.fiks.inn.connectTimeout=10000
@@ -188,8 +188,8 @@ difi.move.feature.enableDPE=false
 
 # Idporten Oidc
 difi.move.oidc.enable=true
-difi.move.oidc.url=https://maskinporten.no/token
-difi.move.oidc.audience=https://maskinporten.no/
+difi.move.oidc.url=https://test.maskinporten.no/token
+difi.move.oidc.audience=https://test.maskinporten.no/
 difi.move.oidc.clientIdPrefix=MOVE_IP_
 difi.move.oidc.clientId=${difi.move.oidc.clientIdPrefix}${difi.move.org.number}
 


### PR DESCRIPTION
`https://meldingsutveksling.difi.no/serviceregistry` er vel utdatert? Endra til `https://eformidling.dev/adressetjeneste`


Er det noken grunn til at `https://eformidling.no/adressetjeneste` ikkje var satt i produksjonsprofilen?
